### PR TITLE
use newer markets endpoint

### DIFF
--- a/mango-service-v3/src/markets.controller.ts
+++ b/mango-service-v3/src/markets.controller.ts
@@ -397,7 +397,7 @@ async function getMarketData(
   marketConfig: MarketConfig
 ): Promise<Partial<MarketDto>> {
   const marketDataResponse = await axios.get(
-    `https://event-history-api-candles.herokuapp.com/markets/` +
+    `https://mango-all-markets-api.herokuapp.com/markets/` +
       `${patchInternalMarketName(marketConfig.name)}`
   );
   return marketDataResponse.data;


### PR DESCRIPTION
Eventually I'd like to remove the /markets endpoint from the candles api, since it has been moved to https://mango-all-markets-api.herokuapp.com/markets/